### PR TITLE
replace deprecated org.codehaus.groovy.grails classes

### DIFF
--- a/src/main/groovy/org/codehaus/groovy/grails/plugins/dto/DefaultGrailsDtoGenerator.groovy
+++ b/src/main/groovy/org/codehaus/groovy/grails/plugins/dto/DefaultGrailsDtoGenerator.groovy
@@ -1,6 +1,6 @@
 package org.codehaus.groovy.grails.plugins.dto
 
-import org.codehaus.groovy.grails.commons.GrailsDomainClass
+import grails.core.GrailsDomainClass
 
 /**
  * Default implementation of the DTO generator. It inspects the domain


### PR DESCRIPTION
This makes the plugin ready for grails <= 3.2